### PR TITLE
Move startup pointer [fixes #29]

### DIFF
--- a/data/remo-start.css
+++ b/data/remo-start.css
@@ -5,7 +5,7 @@
 .addonbarhelper  {
     position: fixed;
     right: 1em;
-    bottom: 1em;
+    top: 1em;
     width: 28em;
     -moz-border-radius: 5px;
     border-radius: 5px;
@@ -18,7 +18,7 @@
     -moz-box-shadow: 0 2px 5px rgba(0,0,0,0.25);
     padding: 0.5em 1em;
     font-size: small;
-    margin: 0;
+    margin: 0 !important;
 }
 
 .addonbarhelper > p:hover {
@@ -26,10 +26,10 @@
     -moz-box-shadow: 0 2px 5px gray;
 }
 
-.down-triangle {
+.up-triangle {
    width: 0;
    height: 0;
-   border-top: 20px solid rgba(0,0,0,0.25);
+   border-bottom: 20px solid rgba(0,0,0,0.25);
    border-left: 10px solid transparent;
    border-right: 10px solid transparent;
    margin-left: 25em;

--- a/data/remo-start.html
+++ b/data/remo-start.html
@@ -132,8 +132,8 @@
     </footer>
 
     <div class="addonbarhelper">
-        <p>Access to the Mozilla Reps Companion is always available via the <span style="font-weight: bold;"/>Add-on Bar</span>. Alternatively, via the Firefox <span style="font-weight: bold;"/>'Customize...'</span> feature, you can drag it into another toolbar.</p>
-            <div class="down-triangle"> </div>
+            <div class="up-triangle"> </div>
+        <p>Access to the Mozilla Reps Companion is always available via the <span style="font-weight: bold;"/>Toolbar</span>. Alternatively, via the Firefox <span style="font-weight: bold;"/>'Customize...'</span> feature, you can drag it into another toolbar.</p>
     </div>
 
 </body>


### PR DESCRIPTION
I've moved the startup message, and modified the text a little (so it doesn't refer to the add-ons bar).

We might want to delay merging this until Australis is released, otherwise it might confuse a few people.

Shown in the current version of Firefox (so with no Australis):
![Picture!](https://f.cloud.github.com/assets/755354/2428312/2b9e5c4e-ac40-11e3-88f7-900b4162878b.png)
